### PR TITLE
PJFCB-3820 Add flag that disables frame extents from computing Scene cordinates in GTK environment

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -42,7 +42,7 @@ jfx.release.suffix=-PSI
 jfx.release.major.version=17
 jfx.release.minor.version=0
 jfx.release.security.version=1
-jfx.release.patch.version=8
+jfx.release.patch.version=9
 
 # Note: The release version is now calculated in build.gradle as the
 # dot-separated concatenation of the previous four fields with trailing zero

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -198,8 +198,12 @@ final class GtkApplication extends Application implements
             }
             return null;
         });
+        boolean gtkNoFrameExtents =
+            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+                return Boolean.getBoolean("jdk.gtk.noFrameExtents");
+            });
 
-        int version = _initGTK(gtkVersion, gtkVersionVerbose, overrideUIScale);
+        int version = _initGTK(gtkVersion, gtkVersionVerbose, overrideUIScale, gtkNoFrameExtents);
 
         if (version == -1) {
             throw new RuntimeException("Error loading GTK libraries");
@@ -228,7 +232,8 @@ final class GtkApplication extends Application implements
      */
     private static native int _queryLibrary(int version, boolean verbose);
 
-    private static native int _initGTK(int version, boolean verbose, float overrideUIScale);
+    private static native int _initGTK(int version, boolean verbose, float overrideUIScale,
+        boolean noFrameExtentds);
 
     private void initDisplay() {
         Map ds = getDeviceDetails();

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -98,13 +98,14 @@ jboolean gtk_verbose = JNI_FALSE;
  * Signature: (IZ)I
  */
 JNIEXPORT jint JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1initGTK
-  (JNIEnv *env, jclass clazz, jint version, jboolean verbose, jfloat uiScale)
+  (JNIEnv *env, jclass clazz, jint version, jboolean verbose, jfloat uiScale, jboolean noFrameExtents)
 {
     (void) clazz;
     (void) version;
 
     OverrideUIScale = uiScale;
     gtk_verbose = verbose;
+    gtk_no_frame_extents = noFrameExtents;
 
     env->ExceptionClear();
     init_threads();

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_screen.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_screen.cpp
@@ -32,6 +32,7 @@
 #include <gdk/gdkx.h>
 
 jfloat OverrideUIScale = -1.0f;
+jboolean gtk_no_frame_extents = JNI_FALSE;
 int DEFAULT_DPI = 96;
 
 static guint get_current_desktop(GdkScreen *screen) {

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_screen.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_screen.h
@@ -31,6 +31,7 @@
 #include <gtk/gtk.h>
 
 extern jfloat OverrideUIScale;
+extern jboolean gtk_no_frame_extents;
 jfloat getUIScale(GdkScreen* screen);
 jobject createJavaScreen(JNIEnv* env, gint monitor_idx);
 glong getScreenPtrForLocation(gint x, gint y);

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -846,11 +846,17 @@ void WindowContextTop::set_cached_extents(WindowFrameExtents ex) {
 }
 
 WindowFrameExtents WindowContextTop::get_cached_extents() {
+    if (gtk_no_frame_extents) {
+        return {0, 0, 0, 0};
+    }
     return window_type == NORMAL ? normal_extents : utility_extents;
 }
 
 
 bool WindowContextTop::update_frame_extents() {
+    if (gtk_no_frame_extents) {
+        return false;
+    }
     bool changed = false;
     int top, left, bottom, right;
     if (get_frame_extents_property(&top, &left, &bottom, &right)) {
@@ -1180,6 +1186,10 @@ void WindowContextTop::set_bounds(int x, int y, bool xSet, bool ySet, int w, int
     requested_bounds.client_width = cw;
     requested_bounds.client_height = ch;
 
+    if (!frame_extents_initialized && gtk_no_frame_extents) {
+        geometry.extents = {0, 0, 0, 0};
+        frame_extents_initialized = true;
+    }
     if (!frame_extents_initialized && frame_type == TITLED) {
         update_frame_extents();
         if (is_null_extents()) {


### PR DESCRIPTION
`-Djdk.gtk.noFrameExtents=true` disables frame extents from computing Scene cordinates in GTK environment