### PR TITLE
PJFCB-11258 Entries disappearing from the attribute list in layout configuration view

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -805,6 +805,9 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         if (vertical == null) {
             vertical = new BooleanPropertyBase(true) {
                 @Override protected void invalidated() {
+                    resetIndex(cells);
+                    resetIndex(pile);
+
                     pile.clear();
                     sheetChildren.clear();
                     cells.clear();
@@ -1073,9 +1076,10 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             lastHeight = -1;
             releaseCell(accumCell);
             sheet.getChildren().clear();
-            for (int i = 0, max = cells.size(); i < max; i++) {
-                cells.get(i).updateIndex(-1);
-            }
+
+            resetIndex(cells);
+            resetIndex(pile);
+
             cells.clear();
             pile.clear();
             releaseAllPrivateCells();
@@ -1083,9 +1087,9 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             lastWidth = -1;
             lastHeight = -1;
             releaseCell(accumCell);
-            for (int i = 0, max = cells.size(); i < max; i++) {
-                cells.get(i).updateIndex(-1);
-            }
+
+            resetIndex(cells);
+
             addAllToPile();
             releaseAllPrivateCells();
         } else if (needsReconfigureCells) {
@@ -1344,6 +1348,18 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         lastPosition = getPosition();
         recalculateEstimatedSize();
         cleanPile();
+    }
+
+    /**
+     * Resets the index to -1 to all cells.
+     * This is to properly clean them up and ensure that no listeners are called because they retain their old index.
+     *
+     * @param cells the cells
+     */
+    private void resetIndex(ArrayLinkedList<T> cells) {
+        for (T cell : cells) {
+            cell.updateIndex(-1);
+        }
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1089,6 +1089,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             releaseCell(accumCell);
 
             resetIndex(cells);
+            resetIndex(pile);
 
             addAllToPile();
             releaseAllPrivateCells();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -47,6 +47,7 @@ import javafx.collections.SetChangeListener;
 import javafx.css.PseudoClass;
 import javafx.scene.Node;
 import javafx.scene.control.Slider;
+import javafx.scene.control.TitledPane;
 import javafx.scene.layout.Region;
 import org.junit.After;
 import test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils;
@@ -5962,5 +5963,44 @@ public class TableViewTest {
         Object result = table.queryAccessibleAttribute(AccessibleAttribute.FOCUS_ITEM);
 
         assertNull(result);
+    }
+
+    /**
+     * The expansion change of a TitledPane triggered an event where the underlying VirtualFlow
+     * was adding cells to the pile and later cleaning them all up without resetting the index to -1.
+     * This led to a bug where two cells received an edit event, although just one should (and is visible).
+     * See also: <a href="https://bugs.openjdk.org/browse/JDK-8320232">JDK-8320232</a>
+     */
+    @Test
+    public void testTitledPaneExpansionShouldCleanupCellsInTableFlow() {
+        AtomicInteger startEditCounter = new AtomicInteger();
+
+        final TableColumn<String, String> col = new TableColumn<>("C");
+        col.setCellValueFactory(value -> new SimpleStringProperty(value.getValue()));
+        col.setCellFactory(eee -> new TableCell<>() {
+            @Override
+            public void startEdit() {
+                startEditCounter.incrementAndGet();
+                super.startEdit();
+            }
+        });
+        table.getColumns().add(col);
+
+        table.setEditable(true);
+        table.getItems().addAll("1", "2", "3");
+
+        TitledPane root = new TitledPane("title", table);
+        root.setAnimated(false);
+        stageLoader = new StageLoader(root);
+
+        root.setExpanded(false);
+        Toolkit.getToolkit().firePulse();
+
+        root.setExpanded(true);
+        Toolkit.getToolkit().firePulse();
+
+        table.edit(0, col);
+
+        assertEquals(1, startEditCounter.get());
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -113,6 +113,7 @@ import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableColumnBaseShim;
 import javafx.scene.control.TableSelectionModel;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TitledPane;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableCellShim;
@@ -7142,5 +7143,49 @@ public class TreeTableViewTest {
 
         Object result = treeTableView.queryAccessibleAttribute(AccessibleAttribute.FOCUS_ITEM);
         assertNull(result);
+    }
+
+    /**
+     * The expansion change of a TitledPane triggered an event where the underlying VirtualFlow
+     * was adding cells to the pile and later cleaning them all up without resetting the index to -1.
+     * This led to a bug where two cells received an edit event, although just one should (and is visible).
+     * See also: <a href="https://bugs.openjdk.org/browse/JDK-8320232">JDK-8320232</a>
+     */
+    @Test
+    public void testTitledPaneExpansionShouldCleanupCellsInTableFlow() {
+        AtomicInteger startEditCounter = new AtomicInteger();
+
+        final TreeTableColumn<String, String> col = new TreeTableColumn<>("C");
+        col.setCellValueFactory(value -> new SimpleStringProperty(value.getValue().getValue()));
+        col.setCellFactory(eee -> new TreeTableCell<>() {
+            @Override
+            public void startEdit() {
+                startEditCounter.incrementAndGet();
+                super.startEdit();
+            }
+        });
+        treeTableView.getColumns().add(col);
+
+        treeTableView.setEditable(true);
+        treeTableView.setRoot(new TreeItem<>("Root"));
+        treeTableView.getRoot().setExpanded(true);
+        for (int i = 0; i < 4; i++) {
+            TreeItem<String> parent = new TreeItem<>("item - " + i);
+            treeTableView.getRoot().getChildren().add(parent);
+        }
+
+        TitledPane root = new TitledPane("title", treeTableView);
+        root.setAnimated(false);
+        stageLoader = new StageLoader(root);
+
+        root.setExpanded(false);
+        Toolkit.getToolkit().firePulse();
+
+        root.setExpanded(true);
+        Toolkit.getToolkit().firePulse();
+
+        treeTableView.edit(0, col);
+
+        assertEquals(1, startEditCounter.get());
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 
@@ -1425,6 +1426,83 @@ public class VirtualFlowTest {
         scene.setRoot(flow);
         assertEquals(flow.shim_getHbar().getValue(), flow.get_clipView_getX(), 0);
     }
+
+
+    @Test
+    public void testVerticalChangeShouldResetIndex() {
+        List<IndexedCell<?>> cells = new ArrayList<>();
+
+        flow = new VirtualFlowShim<>();
+        flow.setVertical(true);
+        flow.setCellFactory(p -> {
+            CellStub cellStub = new CellStub(flow);
+            cells.add(cellStub);
+            return cellStub;
+        });
+        flow.setCellCount(100);
+        flow.setViewportLength(100);
+        flow.resize(100, 100);
+        pulse();
+
+        flow.setVertical(false);
+
+        for (IndexedCell<?> cell : cells) {
+            assertEquals(-1, cell.getIndex());
+        }
+    }
+
+    @Test
+    public void testCellFactoryChangeShouldResetIndex() {
+        List<IndexedCell<?>> cells = new ArrayList<>();
+
+        flow = new VirtualFlowShim<>();
+        flow.setVertical(true);
+        flow.setCellFactory(p -> {
+            CellStub cellStub = new CellStub(flow);
+            cells.add(cellStub);
+            return cellStub;
+        });
+        flow.setCellCount(100);
+        flow.setViewportLength(100);
+        flow.resize(100, 100);
+        pulse();
+
+        flow.setCellFactory(p -> new CellStub(flow));
+
+        pulse();
+
+        for (IndexedCell<?> cell : cells) {
+            assertEquals(-1, cell.getIndex());
+        }
+    }
+
+    @Test
+    public void testRecreateCellsChangeShouldResetIndex() {
+        List<IndexedCell<?>> cells = new ArrayList<>();
+
+        flow = new VirtualFlowShim<>();
+        flow.setVertical(true);
+        flow.setCellFactory(p -> {
+            CellStub cellStub = new CellStub(flow);
+            cells.add(cellStub);
+            return cellStub;
+        });
+        flow.setCellCount(100);
+        flow.setViewportLength(100);
+        flow.resize(100, 100);
+        pulse();
+
+        flow.recreateCells();
+
+        List<IndexedCell<?>> currentCells = new ArrayList<>(cells);
+
+        pulse();
+
+        for (IndexedCell<?> cell : currentCells) {
+            assertEquals(-1, cell.getIndex());
+        }
+    }
+
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {


### PR DESCRIPTION
Cherrypicked fix for https://bugs.openjdk.org/browse/JDK-8320232 - https://github.com/openjdk/jfx/commit/28e3ccc7331952b4d323941c8efc97509348b1e2
Added one more cleanup for indexes in `VirtualFlow` to fix the issue.